### PR TITLE
unzip rule, job resources, and re-enable singularity

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -14,26 +14,46 @@ wildcard_constraints:
 rule all:
     input: expand('funcparc/clustering/seed-ZIR_method-spectralcosine_k-{k}_cluslabels.nii.gz',k=range(2,config['max_k']+1),allow_missing=True)
 
+
+rule unzip_packages:
+    input: 
+        packages = expand(join(config['hcp1200_zip_dir'],'{subject}_{package}.zip'), package=config['hcp_package_dict'].values(), allow_missing=True)
+    params:
+        out_dir = 'hcp1200',
+        files_in_pkg = expand('{filename}',filename=config['hcp_package_dict'].keys())
+    output: 
+        files = expand('hcp1200/{filename}',filename=config['hcp_package_dict'].keys())
+    run: 
+        for pkg,file in zip(input.packages, params.files_in_pkg):
+            shell('unzip {pkg} {file} -d {params.out_dir}')
+
 rule cifti_separate:
-    input: lambda wildcards: glob(config['input_dtseries'].format(**wildcards))
+    input: 
+        dtseries = 'hcp1200/{subject}/MNINonLinear/Results/rfMRI_REST2_7T_AP/rfMRI_REST2_7T_AP_Atlas_1.6mm.dtseries.nii'
     output: 
         lh = 'funcparc/{subject}/input/rfMRI_REST2_7T_AP.L.59k_fs_LR.func.gii',
         rh = 'funcparc/{subject}/input/rfMRI_REST2_7T_AP.R.59k_fs_LR.func.gii'
     singularity: config['singularity_connectomewb']
+    threads: 8
+    resources:
+        mem_mb = 32000
     shell:
         'wb_command -cifti-separate {input} COLUMN -metric CORTEX_LEFT {output.lh} -metric CORTEX_RIGHT {output.rh}'
 
 rule prepare_subcort:
     input:
-        vol = lambda wildcards: glob(config['input_rsvolume'].format(**wildcards)),
+        vol = 'hcp1200/{subject}/MNINonLinear/Results/rfMRI_REST2_7T_AP/rfMRI_REST2_7T_AP.nii.gz',
         rois = config['subcort_atlas']
     output:
         out = 'funcparc/{subject}/input/rfMRI_REST2_7T_AP_AtlasSubcortical.nii.gz'
     params:
         sigma = 1.6,
         temp = 'funcparc/{subject}/temp'
-    #singularity: config['singularity_connectomewb']
+    singularity: config['singularity_connectomewb']
     log: 'logs/prepare_subcort/{subject}.log'
+    threads: 8
+    resources:
+        mem_mb = 32000
     shell: 'scripts/prep_subcortical.sh {input.vol} {input.rois} {params.temp} {params.sigma} {output.out} &> {log}'
 
 rule create_dtseries:
@@ -44,16 +64,21 @@ rule create_dtseries:
         rh = rules.cifti_separate.output.rh
     output: 'funcparc/{subject}/input/rfMRI_REST2_7T_AP.59k_fs_LR.dtseries.nii'
     singularity: config['singularity_connectomewb']
+    threads: 8
+    resources:
+        mem_mb = 32000
     shell:
         'wb_command -cifti-create-dense-timeseries {output} -volume {input.vol} {input.rois} -left-metric {input.lh} -right-metric {input.rh}'
 
 rule extract_confounds:
     input:
-        vol = lambda wildcards: glob(config['input_rsvolume'].format(**wildcards)),
-        rois = lambda wildcards: glob(config['input_rois'].format(**wildcards)),
-        movreg = lambda wildcards: glob(config['input_movreg'].format(**wildcards))
+        vol = 'hcp1200/{subject}/MNINonLinear/Results/rfMRI_REST2_7T_AP/rfMRI_REST2_7T_AP.nii.gz',
+        rois = 'hcp1200/{subject}/MNINonLinear/ROIs/Atlas_wmparc.1.60.nii.gz',
+        movreg = 'hcp1200/{subject}/MNINonLinear/Results/rfMRI_REST2_7T_AP/Movement_Regressors_dt.txt'
     output: 'funcparc/{subject}/input/confounds.tsv'
     log: 'logs/extract_confounds/{subject}.log'
+    resources:
+        mem_mb = 32000
     script: 'scripts/extract_confounds.py'
 
 rule clean_tseries:
@@ -61,8 +86,11 @@ rule clean_tseries:
         dtseries = rules.create_dtseries.output,
         confounds = rules.extract_confounds.output
     output: 'funcparc/{subject}/input_cleaned/rfMRI_REST2_7T_AP.59k_fs_LR.dtseries.nii'
-    #singularity: config['singularity_ciftify']
+    singularity: config['singularity_ciftify']
     log: 'logs/clean_dtseries/{subject}.log'
+    threads: 8
+    resources:
+        mem_mb = 32000
     shell:
         'ciftify_clean_img --output-file={output} --detrend --standardize --confounds-tsv={input.confounds} --low-pass=0.08 --high-pass=0.009 --tr=1 --verbose {input.dtseries} &> {log}'
 
@@ -72,6 +100,9 @@ rule parcellate_tseries:
         rois = config['hcpmmp_atlas']
     output: 'funcparc/{subject}/input_parcellated/rfMRI_REST2_7T_AP.59k_fs_LR.ptseries.nii'
     singularity: config['singularity_connectomewb']
+    threads: 8
+    resources:
+        mem_mb = 32000
     shell:
         'wb_command -cifti-parcellate {input.dtseries} {input.rois} COLUMN {output}'
 

--- a/config.yml
+++ b/config.yml
@@ -1,11 +1,18 @@
 participants_tsv: participants.tsv
-hcp1200_dir: /scratch/rhaast/hcp1200
 
-input_dtseries: /scratch/rhaast/hcp1200/{subject}/MNINonLinear/Results/rfMRI_REST2_7T_AP/rfMRI_REST2_7T_AP_Atlas_1.6mm.dtseries.nii
-input_rsvolume: /scratch/rhaast/hcp1200/{subject}/MNINonLinear/Results/rfMRI_REST2_7T_AP/rfMRI_REST2_7T_AP.nii.gz
-input_rois: /scratch/rhaast/hcp1200/{subject}/MNINonLinear/ROIs/Atlas_wmparc.1.60.nii.gz
-input_movreg: /scratch/rhaast/hcp1200/{subject}/MNINonLinear/Results/rfMRI_REST2_7T_AP/Movement_Regressors_dt.txt
+hcp1200_zip_dir: /project/ctb-akhanf/ext-data/hcp1200/zipfiles
 
+hcp_packages:
+ - 7T_REST_1.6mm_preproc
+ - 7T_REST_preproc_extended
+ - 3T_Structural_1.6mm_preproc
+
+hcp_package_dict:
+ '{subject}/MNINonLinear/Results/rfMRI_REST2_7T_AP/rfMRI_REST2_7T_AP_Atlas_1.6mm.dtseries.nii': 7T_REST_1.6mm_preproc
+ '{subject}/MNINonLinear/Results/rfMRI_REST2_7T_AP/Movement_Regressors_dt.txt': 7T_REST_1.6mm_preproc
+ '{subject}/MNINonLinear/Results/rfMRI_REST2_7T_AP/rfMRI_REST2_7T_AP.nii.gz': 7T_REST_preproc_extended
+ '{subject}/MNINonLinear/ROIs/Atlas_wmparc.1.60.nii.gz': 3T_Structural_1.6mm_preproc
+    
 subcort_atlas: cfg/sub-MNI2009b_desc-allFSstyle_workbench.nii.gz
 hcpmmp_atlas: cfg/HCP-MMP_BigBrain1p6mm.59k_fs_LR.dlabel.nii
 

--- a/scripts/extract_confounds.py
+++ b/scripts/extract_confounds.py
@@ -4,7 +4,7 @@ import nibabel as nib
 from nibabel.nifti1 import Nifti1Image
 from nilearn.input_data import NiftiLabelsMasker
 
-atlas = nib.load(snakemake.input.rois[0])
+atlas = nib.load(snakemake.input.rois)
 labels = atlas.get_fdata()
 
 # Relabel and extract timeseries for CSF and WM labels
@@ -14,7 +14,7 @@ img[labels > 5000] = 2 # WM
 
 tmp = Nifti1Image(img, atlas.affine, atlas.header)
 masker = NiftiLabelsMasker(labels_img=tmp, standardize=False)
-time_series1 = masker.fit_transform(snakemake.input.vol[0])
+time_series1 = masker.fit_transform(snakemake.input.vol)
 
 # Then for whole brain (i.e., 'global')
 brain = np.zeros(labels.shape)
@@ -22,14 +22,14 @@ brain[labels != 0] = 1
 
 tmp = Nifti1Image(brain, atlas.affine, atlas.header)
 masker = NiftiLabelsMasker(labels_img=tmp, standardize=False)
-time_series2 = masker.fit_transform(snakemake.input.vol[0])
+time_series2 = masker.fit_transform(snakemake.input.vol)
 
 # Concatenate timeseries
 df1 = pd.DataFrame({'CSF': time_series1[:, 0],'WhiteMatter': time_series1[:, 1], 'GlobalSignal': time_series2[:, 0]})
 
 # Load movement parameters (and their derivatives)
 names = ['X','Y','Z','RotX','RotY','RotZ','Xd','Yd','Zd','RotXd','RotYd','RotZd']
-df2 = pd.read_csv(snakemake.input.movreg[0], names=names, header=None, delim_whitespace=True)
+df2 = pd.read_csv(snakemake.input.movreg, names=names, header=None, delim_whitespace=True)
 
 # Put everything together (excluding derivatives) and write to .tsv file for 'ciftify_clean_img' 
 df_concat = pd.concat([df2.iloc[:,:6], df1], axis=1)


### PR DESCRIPTION
- added unzip_packages rule that uses a mapping in the config file to find the right zip package and extract each required hcp1200 file
- propagated those inputs to later rules (replacing the glob)
- change in extract_confounds argparsing to accommodate that change from lists to strings
- added 8 threads and 32gb mem for all wb_command jobs (since they can multi-thread and most were running out of memory with default 4gb in cc-slurm

TODO
 - may need to add more mem to later jobs, haven't finished running through to verify!
 - update README to specify requirement of `--singularity-args '\-e'`
 - verify things will work for @royhaast with these changes